### PR TITLE
chore: Updated Rundeck image to `5.18.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/rundeck:5.17.0
+FROM rundeck/rundeck:5.18.0
 LABEL maintainer="Salvoxia <salvoxia@blindfish.info>"
 
 # Prevent Timezone prompt when installing python


### PR DESCRIPTION
  - Updated Rundeck image to v5.18.0